### PR TITLE
Linux compile fix for libpng version, directory slash fix for linux, htons fix for linux pspsdk

### DIFF
--- a/src/Engines/VN/VisualNovelEngine.cpp
+++ b/src/Engines/VN/VisualNovelEngine.cpp
@@ -1,4 +1,4 @@
-#include "..\..\..\include\Engines\VN\VisualNovelEngine.h"
+#include "../../../include/Engines/VN/VisualNovelEngine.h"
 
 namespace Stardust::Engines::VN {
 	VisualNovelEngine::VisualNovelEngine(MarqueeText* mq, Dialogue* dialog, DialogStack* dialogStack, std::string vnFile)

--- a/src/Network/Socket.cpp
+++ b/src/Network/Socket.cpp
@@ -29,7 +29,11 @@ namespace Stardust::Network {
 		m_socket = socket(PF_INET, SOCK_STREAM, 0);
 		struct sockaddr_in name;
 		name.sin_family = AF_INET;
+#ifdef __unix__
+		name.sin_port = __builtin_bswap16(port);
+#elif defined(_WIN32) || defined(WIN32)
 		name.sin_port = htons(port);
+#endif
 
 		inet_pton(AF_INET, ip, &name.sin_addr.s_addr);
 		bool b = (connect(m_socket, (struct sockaddr*) & name, sizeof(name)) >= 0);


### PR DESCRIPTION
libpng version in the windows sdk is 1.4.4 but linux runs 1.5.7. In file VisualNovelEngine.cpp:1:10 i replaced \ with / cause linux file structure i guess. In file Socket.cpp:32:19 fixed the htons error with compile time os check.

1 seg fault error for psp, 2 compile errors for linux fixed.